### PR TITLE
Theatre mode

### DIFF
--- a/src/esl_facebook_client/app/contrib/akamai/controlbar/ControlBar.js
+++ b/src/esl_facebook_client/app/contrib/akamai/controlbar/ControlBar.js
@@ -50,6 +50,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
         muteBtn,
         volumebar,
         fullscreenBtn,
+        theatreBtn,
         timeDisplay,
         durationDisplay,
         thumbnailContainer,
@@ -82,6 +83,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
             muteBtn = document.getElementById(getControlId("muteBtn"));
             volumebar = document.getElementById(getControlId("volumebar"));
             fullscreenBtn = document.getElementById(getControlId("fullscreenBtn"));
+            theatreBtn = document.getElementById(getControlId("theatreBtn"));
             timeDisplay = document.getElementById(getControlId("videoTime"));
             durationDisplay = document.getElementById(getControlId("videoDuration"));
             thumbnailContainer = document.getElementById(getControlId("thumbnail-container")),
@@ -405,6 +407,37 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
             }
             if (trackSwitchMenu) {
                 trackSwitchMenu.classList.add("hide");
+            }
+        },
+
+//************************************************************************************
+// THEATRE MODE
+// Created by JeroenPJ, adapted from fullscreen mode
+//************************************************************************************
+
+        isTheatre = function () {
+            return document.getElementById("player").className.match(/\btheatre\b/) !== null;
+        },
+
+        enterTheatre = function () {
+            document.getElementById("player").classList.add('theatre');
+            var icon = theatreBtn.querySelector(".icon-plus");
+            icon.classList.remove("icon-plus");
+            icon.classList.add("icon-minus");
+        },
+
+        exitTheatre = function () {
+            document.getElementById("player").classList.remove('theatre');
+            var icon = theatreBtn.querySelector(".icon-minus");
+            icon.classList.remove("icon-minus");
+            icon.classList.add("icon-plus");
+        },
+
+        onTheatreClick = function (e) {
+            if (!isTheatre()) {
+                enterTheatre();
+            } else {
+                exitTheatre();
             }
         },
 
@@ -824,6 +857,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
             playPauseBtn.addEventListener("click", onPlayPauseClick);
             muteBtn.addEventListener("click", onMuteClick);
             fullscreenBtn.addEventListener("click", onFullscreenClick);
+            theatreBtn.addEventListener("click", onTheatreClick);
             seekbar.addEventListener("mousedown", onSeeking, true);
             seekbar.addEventListener("mousemove", onSeekBarMouseMove, true);
             // set passive to true for scroll blocking listeners (https://www.chromestatus.com/feature/5745543795965952)
@@ -892,6 +926,7 @@ var ControlBar = function (dashjsMediaPlayer, displayUTCTimeCodes) {
             playPauseBtn.removeEventListener("click", onPlayPauseClick);
             muteBtn.removeEventListener("click", onMuteClick);
             fullscreenBtn.removeEventListener("click", onFullscreenClick);
+            theatreBtn.removeEventListener("click", onTheatreClick);
             seekbar.removeEventListener("mousedown", onSeeking);
             volumebar.removeEventListener("input", setVolume);
             seekbar.removeEventListener("mousemove", onSeekBarMouseMove);

--- a/src/esl_facebook_client/app/css/main.css
+++ b/src/esl_facebook_client/app/css/main.css
@@ -243,7 +243,7 @@ a:hover {
     content: "\e90e";
 }
 .icon-minus:before {
-    content: "\ea0f";
+    content: "\e90f";
 }
 
 

--- a/src/esl_facebook_client/app/css/main.css
+++ b/src/esl_facebook_client/app/css/main.css
@@ -188,9 +188,10 @@ a:hover {
 }
 
 #player.theatre .col-md-3 {
-    /* 35% is too wide, resize to 400px (min: 23%) and put on right side of player */
+    /* 35% is too wide, resize to 400px (min: 23%, max: 31%) and put on right side of player */
     width: 400px;
     min-width: 23%;
+    max-width: 31%;
     
     position: absolute;
     top: 0;
@@ -203,9 +204,10 @@ a:hover {
 }
 
 #player.theatre .col-md-9 {
-    /* since chat is 400px/23% wide, make video wrapper take up rest of space */
+    /* since chat is 400px/23%/31% wide, make video wrapper take up rest of space */
     width: calc(100% - 400px);
     max-width: calc(100% - 23%);
+    min-width: calc(100% - 31%);
     
     position: absolute;
     top: 0;

--- a/src/esl_facebook_client/app/css/main.css
+++ b/src/esl_facebook_client/app/css/main.css
@@ -170,6 +170,64 @@ a:hover {
     position: absolute !important;
 }
 
+
+
+/****************************
+        THEATRE MODE
+*****************************/
+
+#player.theatre {
+    /* make player (video and chat) take up full screen */
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    position: absolute;
+    
+    z-index: 1000;
+}
+
+#player.theatre .col-md-3 {
+    /* 35% is too wide, resize to 400px (min: 23%) and put on right side of player */
+    width: 400px;
+    min-width: 23%;
+    
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    
+    /* remove gutters from cols */
+    padding-left: 0;
+    padding-right: 0;
+}
+
+#player.theatre .col-md-9 {
+    /* since chat is 400px/23% wide, make video wrapper take up rest of space */
+    width: calc(100% - 400px);
+    max-width: calc(100% - 23%);
+    
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    
+    /* remove gutters from cols */
+    padding-left: 0;
+    padding-right: 0;
+    
+    /* center the video vertically */
+    display: flex;
+    justify-content: center;
+    align-items: center; 
+}
+
+#player.theatre .dash-video-player #videoContainer {
+    /* make video as wide as wrapper (necessary with display: flex; on .dash-video-player) */
+    width: 100%;
+}
+
+
 /****************************
         STATS PANELS
 *****************************/

--- a/src/esl_facebook_client/app/css/main.css
+++ b/src/esl_facebook_client/app/css/main.css
@@ -183,7 +183,7 @@ a:hover {
     right: 0;
     bottom: 0;
     position: absolute;
-    
+
     z-index: 1000;
 }
 
@@ -192,12 +192,12 @@ a:hover {
     width: 400px;
     min-width: 23%;
     max-width: 31%;
-    
+
     position: absolute;
     top: 0;
     bottom: 0;
     right: 0;
-    
+
     /* remove gutters from cols */
     padding-left: 0;
     padding-right: 0;
@@ -208,20 +208,20 @@ a:hover {
     width: calc(100% - 400px);
     max-width: calc(100% - 23%);
     min-width: calc(100% - 31%);
-    
+
     position: absolute;
     top: 0;
     bottom: 0;
     left: 0;
-    
+
     /* remove gutters from cols */
     padding-left: 0;
     padding-right: 0;
-    
+
     /* center the video vertically */
     display: flex;
     justify-content: center;
-    align-items: center; 
+    align-items: center;
 }
 
 #player.theatre .dash-video-player #videoContainer {
@@ -231,27 +231,19 @@ a:hover {
 
 
 /* icon for theatre mode. CSS adapted from controlbar.css */
-.icon-plus, .icon-minus {
+.icon-plus,
+.icon-minus {
     font-family: icomoon;
     font-size: 20px;
     color: #fff;
     text-shadow: none;
     -webkit-font-smoothing: antialiased;
 }
-
 .icon-plus:before {
-    content: "\ea0a";
+    content: "\e90e";
 }
 .icon-minus:before {
-    content: "\ea0b";
-}
-
-/* alternative icon pair for theatre, which is an eye with a plus and minus */
-.icon-eye-plus:before {
-    content: "\e9cf";
-}
-.icon-eye-minus:before {
-    content: "\e9d0";
+    content: "\ea0f";
 }
 
 

--- a/src/esl_facebook_client/app/css/main.css
+++ b/src/esl_facebook_client/app/css/main.css
@@ -230,6 +230,32 @@ a:hover {
 }
 
 
+/* icon for theatre mode. CSS adapted from controlbar.css */
+.icon-plus, .icon-minus {
+    font-family: icomoon;
+    font-size: 20px;
+    color: #fff;
+    text-shadow: none;
+    -webkit-font-smoothing: antialiased;
+}
+
+.icon-plus:before {
+    content: "\ea0a";
+}
+.icon-minus:before {
+    content: "\ea0b";
+}
+
+/* alternative icon pair for theatre, which is an eye with a plus and minus */
+.icon-eye-plus:before {
+    content: "\e9cf";
+}
+.icon-eye-minus:before {
+    content: "\e9d0";
+}
+
+
+
 /****************************
         STATS PANELS
 *****************************/

--- a/src/esl_facebook_client/index.html
+++ b/src/esl_facebook_client/index.html
@@ -208,7 +208,7 @@
         </div>
 
         <!--VIDEO PLAYER / CONTROLS -->
-        <div class="row flex-container-row">
+        <div id="player" class="row flex-container-row">
             <div class="dash-video-player col-md-9">
                 <div id="videoContainer" class="videoContainer">
                     <video></video>

--- a/src/esl_facebook_client/index.html
+++ b/src/esl_facebook_client/index.html
@@ -221,6 +221,9 @@
                         <div id="fullscreenBtn" class="btn-fullscreen control-icon-layout" data-toggle="tooltip" data-placement="bottom" title="Fullscreen">
                             <span class="icon-fullscreen-enter"></span>
                         </div>
+                        <div id="theatreBtn" class="btn-theatre control-icon-layout" data-toggle="tooltip" data-placement="bottom" title="Theatre mode">
+                            <span class="icon-plus"></span>
+                        </div>
                         <div id="bitrateListBtn" class="btn-bitrate control-icon-layout" data-toggle="tooltip" data-placement="bottom" title="Bitrate List">
                             <span class="icon-bitrate"></span>
                         </div>


### PR DESCRIPTION
- Added button to controlBar to toggle theatre mode
- Added "#player" ID to wrapper element of video & chat (the .flex-container-row div)
- Added ".theatre" styling for this "#player" element which changes the layout to a theatre mode layout
   NB: this should be very responsive, I've changed chat width to a fixed width with min- and max-width as percentages so it should always be a good width
- Added JavaScript in ControlBar.js to toggle theatre mode (mostly adapted from fullscreen JS)
- Added some CSS to render plus and minus icons as theatre button, from icomoons (same package that's used for the other icons in the control bar)