### PR TITLE
Add toggle sidebar button

### DIFF
--- a/src/esl_facebook_client/app/css/main.css
+++ b/src/esl_facebook_client/app/css/main.css
@@ -127,22 +127,31 @@ a:hover {
     margin-left: 0px;
 }
 
-.dash-video-player {
-    background-color: #000000;
+.player-container {
+    justify-content: space-between;
 }
 
-.col-md-9 video {
+.dash-video-player {
+    background-color: #000000;
+
+}
+
+.dash-video-player video {
     width: 100%;
     height: auto;
     margin: auto;
 }
 
-.col-md-9 {
+.left-col {
     width: 65%;
     padding-top: 15px;
 }
 
-.col-md-3 {
+.left-col.max {
+    width: 100%;
+}
+
+.right-col {
     width: 35%;
 }
 
@@ -188,10 +197,10 @@ a:hover {
     z-index: 1000;
 }
 
-#player.theatre .col-md-3 {
+#player.theatre .right-col {
     /* 35% is too wide, resize to 400px (min: 22%, max: 29%) and put on right side of player */
     width: 350px;
-    min-width: 21%;
+    min-width: 22%;
     max-width: 29%;
 
     position: absolute;
@@ -204,7 +213,7 @@ a:hover {
     padding-right: 0;
 }
 
-#player.theatre .col-md-9 {
+#player.theatre .left-col {
     /* make video wrapper take up the rest of the space, aka 100% minus chat width */
     /* Also add 1px to hide the tiny gap in between video and chat */
     width: calc(100% - 350px + 1px);
@@ -224,6 +233,10 @@ a:hover {
     display: flex;
     justify-content: center;
     align-items: center;
+}
+#player.theatre .left-col.max {
+    width: 100%;
+    max-width: 100%;
 }
 
 #player.theatre .dash-video-player #videoContainer {
@@ -412,11 +425,11 @@ div#legend-wrapper {
 }
 
 @media (min-width: 0px) and (max-width: 992px) {
-    .col-md-9 {
+    .left-col {
         width: 100%;
     }
 
-    .col-md-3 {
+    .right-col {
         width: 100%;
         padding: 0;
         margin-top: 15px;

--- a/src/esl_facebook_client/app/main.js
+++ b/src/esl_facebook_client/app/main.js
@@ -290,6 +290,10 @@ app.controller('DashController', function ($scope, $sce) {
     $scope.toggleShowChart = function () {
         $scope.showChart = !$scope.showChart;
     };
+    $scope.toggleSideBar = function () {
+        $('.dash-video-player').toggleClass('max');
+        $('.tabs-section').toggle();
+    };
     $scope.switchTwitchChatChannel = function () {
         $scope.twitchPrimary = !$scope.twitchPrimary;
     };

--- a/src/esl_facebook_client/index.html
+++ b/src/esl_facebook_client/index.html
@@ -233,8 +233,8 @@
         </div>
 
         <!--VIDEO PLAYER / CONTROLS -->
-        <div id="player" class="row flex-container-row">
-            <div class="dash-video-player col-md-9">
+        <div id="player" class="player-container flex-container-row">
+            <div class="dash-video-player left-col">
                 <div id="videoContainer" class="videoContainer">
                     <video></video>
                     <div id="video-caption"></div>
@@ -278,7 +278,7 @@
             </div>
 
             <!-- STATS TAB CONTENT -->
-            <div class="col-md-3 tabs-section flex-container-column">
+            <div class="tabs-section right-col flex-container-column">
                 <div class="flex-item-grow flex-container-column">
                     <ul class="nav nav-tabs" role="tablist" ng-style="darkMode ? darkNav : lightNav">
                       <li class="active">
@@ -434,6 +434,7 @@
                 <button id="toggle-alternate-server" class="btn btn-primary" ng-click="toggleAlternateServer()" ng-cloak>Alternate Server</button>
                 <button id="switch-twitch-chat-channel" class="btn btn-primary" ng-click="switchTwitchChatChannel()" ng-cloak>Switch Twitch Chat Channel</button>
                 <button id="toggle-show-chart" class="btn btn-primary" ng-click="toggleShowChart()" ng-cloak>Toggle Show Chart</button>
+                <button id="toggle-side-bar" class="btn btn-primary" ng-click="toggleSideBar()" ng-cloak>Toggle Sidebar</button>
             </div>
         </div>
 


### PR DESCRIPTION
### Description: 
There is currently no way to hide the sidebar completely, this adds a button for that.

#### Notes:

* The css currently references and overrides bootstrap grid classes (`col-md-*`) which is a bad practice. It overrode the width, so I just opted to create standard class names instead of the bootstrap ones. So now its just driven by flex.

* The app doesnt seem to handle responsiveness (one of the main reasons for using bootstrap grids in the first place) so I didnt add support for small screens. Its not any worse than it was before.

* Should work in theatre mode, but theres no way to toggle it once its open

### Screenshot

![oct-05-2018 11-05-58](https://user-images.githubusercontent.com/3419227/46546450-b1e0a180-c88e-11e8-8b18-e8ae7fabaaa3.gif)
